### PR TITLE
안드로이드에서 사진 캡쳐 시 Flash 대신 Torch를 사용하도록 변경

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
@@ -32,6 +32,8 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
     }
   }
 
+  // by - sds : 특정 기기(Z플립4)에서 Flash를 키면 Capture 처리 속도가 떨어져서 torch를 사용하도록 변경
+  /*
   if (options.hasKey("flash")) {
     val flashMode = options.getString("flash")
     imageCapture!!.flashMode = when (flashMode) {
@@ -41,6 +43,7 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
       else -> throw InvalidTypeScriptUnionError("flash", flashMode ?: "(null)")
     }
   }
+   */
   // All those options are not yet implemented - see https://github.com/mrousavy/react-native-vision-camera/issues/75
   if (options.hasKey("photoCodec")) {
     // TODO photoCodec
@@ -64,6 +67,16 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
 
   val camera2Info = Camera2CameraInfo.from(camera!!.cameraInfo)
   val lensFacing = camera2Info.getCameraCharacteristic(CameraCharacteristics.LENS_FACING)
+
+  // by - sds : Flash 옵션 값에 따라 torch on/off 처리
+  try {
+    if (options.hasKey("flash")) {
+      val isFlashOn = options.getString("flash") == "on"
+      camera!!.cameraControl.enableTorch(isFlashOn)
+    }
+  } catch (e: Exception) {
+    e.printStackTrace()
+  }
 
   val results = awaitAll(
     async(coroutineContext) {

--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -304,6 +304,16 @@ class CameraView(context: Context, private val frameProcessorThread: ExecutorSer
   override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()
     updateLifecycleState()
+
+    // by - sds : CameraView가 있던 화면을 벗어나도 torch가 켜져 있는 상황이 발생해서 추가
+    coroutineScope.launch {
+      try {
+        configureSession()
+      } catch (e: Throwable) {
+        Log.e(TAG, "onDetachedFromWindow() threw: ${e.message}")
+        invokeOnError(e)
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
### 1. 핵심 고려사항
- `takePhoto()` 호출 시 Flash 대신 `Torch`를 사용하도록 변경

### 2. 작업 배경 (연관된 PR 번호, 간단한 설명)
- 안드로이드 특정 기기에서 Flash를 키고 사진을 찍으면 6초 정도 딜레이가 발생해서 너무 느리다

