### PR TITLE
PD-6222 fix: AVCaptureDevice.Position has unknown state

### DIFF
--- a/ios/Parsers/AVCaptureColorSpace+descriptor.swift
+++ b/ios/Parsers/AVCaptureColorSpace+descriptor.swift
@@ -38,7 +38,7 @@ extension AVCaptureColorSpace {
     case .sRGB:
       return "srgb"
     default:
-      fatalError("AVCaptureDevice.Position has unknown state.")
+      return "unknown"
     }
   }
 }


### PR DESCRIPTION
[PD-6222]
iPhone 15 Pro, Pro Max

https://console.firebase.google.com/project/kickgoing-1525066851402/crashlytics/app/ios:com.olulo.kickgoing/issues/6917b4f56339d8ada25011d75ec54e83?hl=ko&time=last-thirty-days&sessionEventKey=a3d348ca28bf4d0fa7797a83aabcc30a_1863696965044960463&sessionTab=data&userInfoQuery=BE62JS

https://github.com/mrousavy/react-native-vision-camera/commit/503114b9d1c61d60fa3c69b3bd4cb084758fbf5b

[PD-6222]: https://olulo.atlassian.net/browse/PD-6222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ