### PR TITLE
PD-6078 fix: Swift class extensions and categories on Swift classes are not allowed to have +load methods

### DIFF
--- a/ios/Frame Processor/FrameProcessorPlugin.h
+++ b/ios/Frame Processor/FrameProcessorPlugin.h
@@ -49,11 +49,11 @@
 objc_name : NSObject<FrameProcessorPluginBase>                                      \
 @end                                                                                \
                                                                                     \
-@interface objc_name (FrameProcessorPlugin)                                         \
+@interface objc_name (FrameProcessorPlugin) <FrameProcessorPluginBase>              \
 @end                                                                                \
 @implementation objc_name (FrameProcessorPlugin)                                    \
                                                                                     \
-+(void)load                                                                          \
+__attribute__((constructor)) static void VISION_CONCAT(initialize_, objc_name)()    \
 {                                                                                   \
   [FrameProcessorPluginRegistry addFrameProcessorPlugin:@"__" @ #name callback:^id(Frame* frame, NSArray<id>* args) {    \
     return [objc_name callback:frame withArgs:args];                               \


### PR DESCRIPTION
[PD-6078]

Swift class extensions and categories on Swift classes are not allowed to have +load methods

실행하자마자 사망

https://github.com/mrousavy/react-native-vision-camera/issues/1802

https://github.com/mrousavy/react-native-vision-camera/releases/tag/v2.16.1

https://medium.com/@toyboy2/xcode-15-react-native-troubleshooting-guides-e559ac246bae

[PD-6078]: https://olulo.atlassian.net/browse/PD-6078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ